### PR TITLE
Fixed font call for responsive-nav

### DIFF
--- a/sass/modules/_nav.scss
+++ b/sass/modules/_nav.scss
@@ -553,7 +553,10 @@ menu {
 //$border-color
 //$nav-background-color
 //All these scss variables and more can be found in _default-settings.scss
-
+.nav-toggle:before{
+  content: "\f0c9";
+  font-family: "FontAwesome";
+}
 .nav-link:hover, .nav-link:link:hover, .nav-link:visited:hover{
   color: $link-hover-color !important;
 }


### PR DESCRIPTION
Font-family needed to be specified. Not sure how this was working before.
