### PR TITLE
 #21 Remove slash on disabled buttons

### DIFF
--- a/sass/modules/_buttons.scss
+++ b/sass/modules/_buttons.scss
@@ -53,15 +53,9 @@
     box-shadow: none;
     text-shadow: none;
 
-    &:after {
-      content: '\005C';
-      display: block;
-      position: absolute;
-      top: 10px;
-      left: 50%;
-      margin-left: -8px;
-      font-size: 70px;
-      color: #6d6d6d;
+    &:hover {
+      background: none;
+      cursor: not-allowed;
     }
   }
 }


### PR DESCRIPTION
Remove slash on disabled buttons; use "not-allowed" cursor instead to indicate that the buttons are disabled.